### PR TITLE
Add the flexibility to pass the url of the Dropin initialise script

### DIFF
--- a/src/GoCardlessDropinButton.tsx
+++ b/src/GoCardlessDropinButton.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useGoCardlessDropin } from "./hooks";
-import { GoCardlessDropinOptions } from "./types";
 import "./GoCardlessDropinButton.css";
+import { useGoCardlessDropinOptions } from "./types";
 
 // Opens a Billing Request Flow in a modal. Relies on GoCardlessDropin being
 // loaded into window, which will only happen if the initialise script has been
 // loaded via a script tag.
-export const GoCardlessDropinButton = (options: GoCardlessDropinOptions) => {
+export const GoCardlessDropinButton = (options: useGoCardlessDropinOptions) => {
   const { open } = useGoCardlessDropin({ ...options });
 
   return (

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import useScript from "react-script-hook";
 
-import { GoCardlessDropinHandler, GoCardlessDropinOptions } from "./types";
+import { GoCardlessDropinHandler, useGoCardlessDropinOptions } from "./types";
 
 // This is where GoCardless hosts the Dropin initialise script. Compatibility is
 // guaranteed across the same major version- no one should be trying to use a different
@@ -20,7 +20,7 @@ type useGoCardlessDropinResult = {
 const noop = () => {};
 
 export const useGoCardlessDropin = (
-  options: GoCardlessDropinOptions & { initialiseURL?: string }
+  options: useGoCardlessDropinOptions
 ): useGoCardlessDropinResult => {
   // Asynchronously load the initialise script. This should make GoCardlessDropin
   // available on window.

--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -3,12 +3,24 @@ import { action } from "@storybook/addon-actions";
 
 import { GoCardlessDropinButton } from ".";
 
-// Render the GoCardlessDropinButton, which allows triggering of a new Dropin
-// modal.
-//
-// In future, we may want to provide an additional button that can populate the
-// BRF ID on behalf of the user, using our demo link in sandbox.
-//
+const urlFor: { [key: string]: string } = {
+  sandbox:
+    "https://pay-sandbox.gocardless.com/billing/static/dropin/v2/initialise.js",
+  localhost: "http://localhost:3012/billing/static/dropin/v2/initialise.js",
+};
+
+/**
+ * Get the billingRequestFlowID by running our demo link and
+ * update billingRequestFlowID control with it to view the storybook
+ */
+
+/**
+ * Render the GoCardlessDropinButton, which allows triggering of a new Dropin
+ * modal.
+ *
+ * In future, we may want to provide an additional button that can populate the
+ * BRF ID on behalf of the user, using our demo link in sandbox.
+ */
 export const Base = ({
   billingRequestFlowID,
   environment,
@@ -18,6 +30,7 @@ export const Base = ({
 }) => {
   return (
     <GoCardlessDropinButton
+      initialiseURL={urlFor[environment]}
       billingRequestFlowID={billingRequestFlowID}
       environment={environment}
       onSuccess={action("onSuccess")}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,16 @@ export type GoCardlessDropinOptions = ClientCallbacks & {
   domain?: string;
 };
 
+export type useGoCardlessDropinOptions = GoCardlessDropinOptions & {
+  /**
+   * initialiseURL will allow to overwrite the url of the Dropin initialise script
+   * for eg. if you are interested in passing the url for sandbox or local
+   * environment. If not passed, it will pick the live-production one where
+   * GoCardless hosts the Dropin initialise script
+   */
+  initialiseURL?: string;
+};
+
 export type GoCardlessDropinOnSuccess = (
   billingRequest: BillingRequest,
   billingRequestFlow: BillingRequestFlow


### PR DESCRIPTION
initialiseURL will allow to overwrite the url of the Dropin initialise script for eg. if you are interested in passing the url for sandbox or local environment. If not passed, it will pick the live-production one where GoCardless hosts the Dropin initialise script