### PR TITLE
fix: publish to npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
         run: npm install
         env:
           NODE_ENV: development
-          NODE_AUTH_TOKEN: ${{ secrets.ROBOT_PACKAGE_WRITER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run lint
 
-  publish:
+  publish_to_github:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs:
@@ -51,9 +51,36 @@ jobs:
       - name: Build
         run: npm run build
       - name: Publish package
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish_to_npm:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs:
+      - build_and_lint
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+      - name: restore_cache
+        uses: actions/cache@v3
+        with:
+          key: npm-v1-{{ hashFiles(".nvmrc") }}-{{ hashFiles("package-lock.json") }}
+          restore-keys: npm-v1-{{ hashFiles(".nvmrc") }}
+          path: node_modules
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Publish package
         run: npm publish --access=public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   storybook_publish:
     if: github.ref == 'refs/heads/master'
@@ -76,7 +103,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.ROBOT_PACKAGE_WRITER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build-storybook
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/gocardless"
-  },
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "lint": "eslint '{src,examples}/**/*.{ts,tsx,js,jsx}' --ignore-path .gitignore",


### PR DESCRIPTION
Need to split the publishing into two here as it seems npm can't handle publishing to multiple registries easily. I also created a new token so we can publish to npm, set this as a repository secret, and popped this in the dev-en vault, for future reference.

A previous [run](https://github.com/gocardless/react-dropin/actions/runs/5865972813/job/15903930895) successfully published to npm ([here](https://www.npmjs.com/package/@gocardless/react-dropin))