### PR TITLE
fix: use legacy openssl whilst building storybook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build-storybook
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,3 +28,7 @@ jobs:
         run: npm run lint
       - name: Build
         run: npm run build
+      - name: Build Storybook
+        run: npm run build-storybook
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider


### PR DESCRIPTION
Storybook build also failed after merge 😞

Found a workaround (again, short of actually updating everything fully in this repo) and also added attempting to build storybook to the PR checks.

Once the storybook deployment works, I'll cut a tag to publish.