### PR TITLE
fix: run ci when adding tags/ releases from github UI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 on:
   push:
     branches: [master]
+  tags:
+    - "v*"
 
 permissions:
   packages: write


### PR DESCRIPTION
Release from github UI as stated in readme didn't trigger a release. I think this is since i split the workflows and added the main build one to only run on master. This should fix that and still keep it separate from feature branch workflows but also run on tag creation.