### PR TITLE
fix: run ci when publishing a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build
 on:
   push:
     branches: [master]
-  tags:
-    - "v*"
+  release:
+    types: [published]
 
 permissions:
   packages: write
@@ -33,7 +33,7 @@ jobs:
       - run: npm run lint
 
   publish_to_github:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs:
       - build_and_lint
@@ -60,7 +60,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_to_npm:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs:
       - build_and_lint


### PR DESCRIPTION
Hmm, my tag approach didn't work, I think the syntax was wrong, but I was reading the github docs and I think a more appropriate event to trigger a release in this instance thats close to what was there before is on publish of a release, this way, when drafting a release (and creating a tag) the release will not be published then, only after the actual github release is finalised and published with that tag.